### PR TITLE
Adding willConfigure & didConfigure methodes to delegate

### DIFF
--- a/SwiftDocumentScanner/Classes/Controllers/DocumentCropViewController.swift
+++ b/SwiftDocumentScanner/Classes/Controllers/DocumentCropViewController.swift
@@ -13,6 +13,8 @@ public protocol DocumentCropViewControllerDelegate: class {
 
 	func documentCropViewController(result: Result)
 	func documentCropViewController(failed: Error)
+	func documentCropViewControllerWillConfigure()
+	func documentCropViewControllerDidConfigure()
 
 }
 
@@ -60,6 +62,9 @@ open class DocumentCropViewController: UIViewController {
 	}
 
 	public func configure() {
+		DispatchQueue.main.async { [weak self] in
+			self?.cropDelegate?.documentCropViewControllerWillConfigure()
+		}
 		image = image?.fixOrientation()
 		imageView.transform = CGAffineTransform.identity
 		imageView.image = image
@@ -68,6 +73,9 @@ open class DocumentCropViewController: UIViewController {
 
 		guard let image = image else { return }
 		rectangleDetector.detect(image: image, completion: handleDetection)
+		DispatchQueue.main.async { [weak self] in
+			self?.cropDelegate?.documentCropViewControllerDidConfigure()
+		}
 	}
 
 	private func updateCropview() {


### PR DESCRIPTION
Like I explained in #9, I was able to make those work after running "Clean Build Folder" from "Product" menu in xCode.
- If you know how - you may want to make those 2 new methods optional, 'cause they're not must.
- If there is need for something like `DispatchQueue.global(qos: .userInitiated).async` that you've included in the other calls for the delegate methods, you may add it (I didn't know if this is related to the cropping itself or to the delegate methods).

Thanks,
Ido.