### PR TITLE
Fix xCode 11 warnings

### DIFF
--- a/SwiftDocumentScanner/Classes/Extensions/Array+extension.swift
+++ b/SwiftDocumentScanner/Classes/Extensions/Array+extension.swift
@@ -9,7 +9,7 @@ import UIKit
 
 public extension Array where Element == CGPoint {
 
-	public var quadPath: UIBezierPath {
+	var quadPath: UIBezierPath {
 		let path = UIBezierPath()
 
 		guard count == 4 else { return path }

--- a/SwiftDocumentScanner/Classes/Extensions/UIImage+Extension.swift
+++ b/SwiftDocumentScanner/Classes/Extensions/UIImage+Extension.swift
@@ -9,7 +9,7 @@ import UIKit
 
 public extension UIImage {
 
-	public func fixOrientation(orientation: UIImage.Orientation? = nil) -> UIImage {
+	func fixOrientation(orientation: UIImage.Orientation? = nil) -> UIImage {
 		guard orientation == nil && imageOrientation != .up else { return self }
 
 		var transform = CGAffineTransform.identity


### PR DESCRIPTION
'public' modifier is redundant for instance method declared in a public extension