### PR TITLE
Fix deprecated code

### DIFF
--- a/SwiftDocumentScanner/Classes/Controllers/CameraViewController.swift
+++ b/SwiftDocumentScanner/Classes/Controllers/CameraViewController.swift
@@ -9,7 +9,7 @@ import AVFoundation
 import Foundation
 import UIKit
 
-public protocol CameraViewControllerDelegate: class {
+public protocol CameraViewControllerDelegate: AnyObject {
 
     func cameraViewController(didFocus point: CGPoint)
     func cameraViewController(update status: AVAuthorizationStatus)

--- a/SwiftDocumentScanner/Classes/Detectors/AutoDetector.swift
+++ b/SwiftDocumentScanner/Classes/Detectors/AutoDetector.swift
@@ -8,7 +8,7 @@
 import CoreImage
 import CoreGraphics
 
-public protocol AutoDetectorDelegate: class {
+public protocol AutoDetectorDelegate: AnyObject {
 
 	func detector(update: Observation)
 	func detector(success: Observation)


### PR DESCRIPTION
Fix warning: `Using 'class' keyword to define a class-constrained protocol is deprecated; use 'AnyObject' instead`